### PR TITLE
Create ROOT dictionaries in the current "build" directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-#ignore build results
+# GNU make and CMake in-place build results to ignore
 WCSimRootDict.cxx
 WCSimRootDict.h
 libWCSim.a
@@ -9,18 +9,22 @@ make.out.txt
 bin/
 tmp/
 doxygen/
+# CMake in-place build results to ignore
 CMakeCache.txt
 CMakeFiles/
 Makefile
 WCSim
 cmake_install.cmake
 cmake.out.txt
+# VS Code in-place build results to ignore
+.vscode/
+build/
 
-#ignore run results
+# run results to ignore
 *.root
 geofile.txt
 
-#ignore compiled ROOT scripts
+# compiled ROOT scripts to ignore
 *_C.d
 *_C.so
 *_cxx.d
@@ -28,5 +32,5 @@ geofile.txt
 *_cc.d
 *_cc.so
 
-##ignore compiled python scripts
+## compiled python scripts to ignore
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 #ignore build results
+src/WCSimRootDict.cxx
 src/WCSimRootDict.cc
 src/WCSimRootDict.h
 libWCSim.a

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 #ignore build results
-src/WCSimRootDict.cxx
-src/WCSimRootDict.cc
-src/WCSimRootDict.h
+WCSimRootDict.cxx
+WCSimRootDict.h
 libWCSim.a
 libWCSimRoot.so
 make.rootcint.result
 make.result
+make.out.txt
+cmake.out.txt
 bin/
 tmp/
 doxygen/

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,15 @@ libWCSimRoot.so
 make.rootcint.result
 make.result
 make.out.txt
-cmake.out.txt
 bin/
 tmp/
 doxygen/
+CMakeCache.txt
+CMakeFiles/
+Makefile
+WCSim
+cmake_install.cmake
+cmake.out.txt
 
 #ignore run results
 *.root

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,13 @@ include_directories(${PROJECT_SOURCE_DIR}/include
 # in standard makefile, need to make rootcint anyway before standard make
 #
 
-## WCSimRootDict.cc regeneration by rootcint
+## WCSimRootDict.cxx regeneration by rootcint
 ## Use ROOT 5.34.32 as some issues with PARSE_ARGUMENTS were found in older ROOT versions (ROOT 5.34.11)
-ROOT_GENERATE_DICTIONARY(${CMAKE_CURRENT_SOURCE_DIR}/src/WCSimRootDict ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootEvent.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootGeom.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimPmtInfo.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimEnumerations.hh  ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootOptions.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/TJNuBeamFlux.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/TNRooTrackerVtx.hh LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootLinkDef.hh)
+ROOT_GENERATE_DICTIONARY(WCSimRootDict ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootEvent.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootGeom.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimPmtInfo.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimEnumerations.hh  ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootOptions.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/TJNuBeamFlux.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/TNRooTrackerVtx.hh LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootLinkDef.hh)
 
 
 ## Crucial for reading ROOT classes: make shared object library
-add_library(WCSimRoot SHARED ./src/WCSimRootEvent.cc ./src/WCSimRootGeom.cc ./src/WCSimPmtInfo.cc ./src/WCSimEnumerations.cc ./src/WCSimRootOptions.cc ./src/TJNuBeamFlux.cc ./src/TNRooTrackerVtx.cc ./src/WCSimRootDict.cxx)
+add_library(WCSimRoot SHARED ./src/WCSimRootEvent.cc ./src/WCSimRootGeom.cc ./src/WCSimPmtInfo.cc ./src/WCSimEnumerations.cc ./src/WCSimRootOptions.cc ./src/TJNuBeamFlux.cc ./src/TNRooTrackerVtx.cc WCSimRootDict.cxx)
 target_link_libraries(WCSimRoot  ${ROOT_LIBRARIES})
 
 
@@ -104,7 +104,7 @@ set(WCSIM_SCRIPTS
   macros/visOGLSX.mac
   macros/visOGLQT.mac
   macros/visRayTracer.mac
-  macros/mPMT.mac
+  # macros/mPMT.mac
   macros/mPMT_nuPrism1.mac
   macros/mPMT_nuPrism2.mac
   macros/tuning_parameters.mac

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ else()
 endif()
 
 # Set flag for git version to be used as c++ preprocessor macro
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`git -C ${PROJECT_SOURCE_DIR} describe --always --long --tags --dirty`\\\"\"")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`cd ${PROJECT_SOURCE_DIR};git describe --always --long --tags --dirty`\\\"\"")
 
 add_executable(WCSim WCSim.cc ${sources} ${headers})
 target_link_libraries(WCSim ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} WCSimRoot Tree)  #add profiler to use gperftools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ else()
 endif()
 
 # Set flag for git version to be used as c++ preprocessor macro
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`git describe --always --long --tags --dirty`\\\"\"")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`git -C ${PROJECT_SOURCE_DIR} describe --always --long --tags --dirty`\\\"\"")
 
 add_executable(WCSim WCSim.cc ${sources} ${headers})
 target_link_libraries(WCSim ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} WCSimRoot Tree)  #add profiler to use gperftools

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -83,7 +83,7 @@ doxy:
 
 clean_wcsim:
 	echo  $(G4WORKDIR); 
-	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ src/WCSimRootDict.h src/WCSimRootDict.cxx; 
+	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ src/WCSimRootDict.*
 	@if [ -d "doc/doxygen" ]; \
 		then \
 		rm -r doc/doxygen; \

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -51,7 +51,7 @@ endif
 CPPFLAGS += -DGIT_HASH=\"$(shell git describe --always --long --tags --dirty)\"
 
 .PHONY: all
-all: rootcint lib bin shared libWCSim.a
+all: rootcint shared libWCSim.a lib bin
 
 # Note dependencies not yet set up right yet
 
@@ -90,3 +90,10 @@ clean_wcsim:
 	fi	
 
 include $(G4INSTALL)/config/binmake.gmk
+
+$(G4TMPDIR)/%.o: src/%.cxx
+	@echo Compiling $*.cxx ...
+	@if [ ! -d $(G4TMPDIR) ] ; then echo mkdir -p $(G4TMPDIR) ; mkdir -p $(G4TMPDIR) ; fi
+	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(OUT_OBJ)$(G4TMPDIR)/$(*F).o src/$*.cxx
+	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(OUT_OBJ)$(G4TMPDIR)/$(*F).o src/$*.cxx
+

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -94,6 +94,6 @@ include $(G4INSTALL)/config/binmake.gmk
 $(G4TMPDIR)/%.o: %.cxx
 	@echo Compiling $*.cxx ...
 	@if [ ! -d $(G4TMPDIR) ] ; then echo mkdir -p $(G4TMPDIR) ; mkdir -p $(G4TMPDIR) ; fi
-	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(OUT_OBJ)$(G4TMPDIR)/$(*F).o $*.cxx
-	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(OUT_OBJ)$(G4TMPDIR)/$(*F).o $*.cxx
+	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $*.cxx
+	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $*.cxx
 

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -68,10 +68,10 @@ libWCSim.a : $(ROOTOBJS)
 	$(RM) $@
 	ar clq $@ $(ROOTOBJS) 
 
-./src/WCSimRootDict.cxx : $(ROOTSRC)
-	rootcint  -f ./src/WCSimRootDict.cxx -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh TJNuBeamFlux.hh TNRooTrackerVtx.hh WCSimRootLinkDef.hh
+./WCSimRootDict.cxx : $(ROOTSRC)
+	rootcint  -f ./WCSimRootDict.cxx -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh TJNuBeamFlux.hh TNRooTrackerVtx.hh WCSimRootLinkDef.hh
 
-rootcint: ./src/WCSimRootDict.cxx
+rootcint: ./WCSimRootDict.cxx
 
 doxy:
 	@if [ ${DOXYGEN_EXISTS} = 1 ]; \
@@ -83,7 +83,7 @@ doxy:
 
 clean_wcsim:
 	echo  $(G4WORKDIR); 
-	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ src/WCSimRootDict.*
+	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ ./WCSimRootDict.*
 	@if [ -d "doc/doxygen" ]; \
 		then \
 		rm -r doc/doxygen; \
@@ -91,9 +91,9 @@ clean_wcsim:
 
 include $(G4INSTALL)/config/binmake.gmk
 
-$(G4TMPDIR)/%.o: src/%.cxx
+$(G4TMPDIR)/%.o: %.cxx
 	@echo Compiling $*.cxx ...
 	@if [ ! -d $(G4TMPDIR) ] ; then echo mkdir -p $(G4TMPDIR) ; mkdir -p $(G4TMPDIR) ; fi
-	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(OUT_OBJ)$(G4TMPDIR)/$(*F).o src/$*.cxx
-	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(OUT_OBJ)$(G4TMPDIR)/$(*F).o src/$*.cxx
+	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(OUT_OBJ)$(G4TMPDIR)/$(*F).o $*.cxx
+	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(OUT_OBJ)$(G4TMPDIR)/$(*F).o $*.cxx
 

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -68,10 +68,10 @@ libWCSim.a : $(ROOTOBJS)
 	$(RM) $@
 	ar clq $@ $(ROOTOBJS) 
 
-./src/WCSimRootDict.cc : $(ROOTSRC)
-	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh TJNuBeamFlux.hh TNRooTrackerVtx.hh WCSimRootLinkDef.hh
+./src/WCSimRootDict.cxx : $(ROOTSRC)
+	rootcint  -f ./src/WCSimRootDict.cxx -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh TJNuBeamFlux.hh TNRooTrackerVtx.hh WCSimRootLinkDef.hh
 
-rootcint: ./src/WCSimRootDict.cc
+rootcint: ./src/WCSimRootDict.cxx
 
 doxy:
 	@if [ ${DOXYGEN_EXISTS} = 1 ]; \
@@ -83,7 +83,7 @@ doxy:
 
 clean_wcsim:
 	echo  $(G4WORKDIR); 
-	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ src/WCSimRootDict.h src/WCSimRootDict.cc; 
+	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ src/WCSimRootDict.h src/WCSimRootDict.cxx; 
 	@if [ -d "doc/doxygen" ]; \
 		then \
 		rm -r doc/doxygen; \

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -46,11 +46,11 @@ libWCSimRoot.so : $(ROOTOBJS)
 	@if [ ! -d $(G4TMPDIR) ] ; then mkdir $(G4TMPDIR) ; echo mkdir $(G4TMPDIR) ;fi
 	@$(CXX) -shared -O $^ -o $(ROOTSO) $(ROOTLIBS)
 
-./src/WCSimRootDict.cc : $(ROOTSRC)
+./src/WCSimRootDict.cxx : $(ROOTSRC)
 	@echo Compiling rootcint ...
-	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh WCSimRootLinkDef.hh
+	rootcint  -f ./src/WCSimRootDict.cxx -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh WCSimRootLinkDef.hh
 
-rootcint: ./src/WCSimRootDict.cc
+rootcint: ./src/WCSimRootDict.cxx
 
 $(G4TMPDIR)/%.o: src/%.cc
 	@echo Compiling $*.cc ...
@@ -60,5 +60,5 @@ $(G4TMPDIR)/%.o: src/%.cc
 
 clean :
 	@rm -f $(G4TMPDIR)/*.o
-	@rm -f ./src/WCSimRootDict.cc
+	@rm -f ./src/WCSimRootDict.h ./src/WCSimRootDict.cxx
 

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -46,11 +46,11 @@ libWCSimRoot.so : $(ROOTOBJS)
 	@if [ ! -d $(G4TMPDIR) ] ; then mkdir $(G4TMPDIR) ; echo mkdir $(G4TMPDIR) ;fi
 	@$(CXX) -shared -O $^ -o $(ROOTSO) $(ROOTLIBS)
 
-./src/WCSimRootDict.cxx : $(ROOTSRC)
+./WCSimRootDict.cxx : $(ROOTSRC)
 	@echo Compiling rootcint ...
-	rootcint  -f ./src/WCSimRootDict.cxx -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh WCSimRootLinkDef.hh
+	rootcint  -f ./WCSimRootDict.cxx -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh WCSimRootLinkDef.hh
 
-rootcint: ./src/WCSimRootDict.cxx
+rootcint: ./WCSimRootDict.cxx
 
 $(G4TMPDIR)/%.o: src/%.cc
 	@echo Compiling $*.cc ...
@@ -58,7 +58,7 @@ $(G4TMPDIR)/%.o: src/%.cc
 	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $<
 	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $<
 
-$(G4TMPDIR)/%.o: src/%.cxx
+$(G4TMPDIR)/%.o: %.cxx
 	@echo Compiling $*.cxx ...
 	@if [ ! -d $(G4TMPDIR) ] ; then mkdir $(G4TMPDIR) ; echo mkdir $(G4TMPDIR) ;fi
 	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $<
@@ -66,5 +66,5 @@ $(G4TMPDIR)/%.o: src/%.cxx
 
 clean :
 	@rm -f $(G4TMPDIR)/*.o
-	@rm -f ./src/WCSimRootDict.*
+	@rm -f ./WCSimRootDict.*
 

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -60,5 +60,5 @@ $(G4TMPDIR)/%.o: src/%.cc
 
 clean :
 	@rm -f $(G4TMPDIR)/*.o
-	@rm -f ./src/WCSimRootDict.h ./src/WCSimRootDict.cxx
+	@rm -f ./src/WCSimRootDict.*
 

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -58,6 +58,12 @@ $(G4TMPDIR)/%.o: src/%.cc
 	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $<
 	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $<
 
+$(G4TMPDIR)/%.o: src/%.cxx
+	@echo Compiling $*.cxx ...
+	@if [ ! -d $(G4TMPDIR) ] ; then mkdir $(G4TMPDIR) ; echo mkdir $(G4TMPDIR) ;fi
+	@echo $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $<
+	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $(G4TMPDIR)/$(*F).o $<
+
 clean :
 	@rm -f $(G4TMPDIR)/*.o
 	@rm -f ./src/WCSimRootDict.*

--- a/README.ROOT
+++ b/README.ROOT
@@ -27,7 +27,7 @@ Root related files:
 ./src/WCSimRootGeom.cc, ./include/WCSimRootGeom.hh
   These are the WCSimRootGeom class files 
 
-./src/WCSimRootDict.cc, ./src/WCSimRootDict.hh
+./src/WCSimRootDict.cxx, ./src/WCSimRootDict.h
   These are the Root dictionary files created by rootcint
 (they are not in the repository); they are made by 
 gmake rootcint

--- a/README.ROOT
+++ b/README.ROOT
@@ -27,7 +27,7 @@ Root related files:
 ./src/WCSimRootGeom.cc, ./include/WCSimRootGeom.hh
   These are the WCSimRootGeom class files 
 
-./src/WCSimRootDict.cxx, ./src/WCSimRootDict.h
+./WCSimRootDict.cxx, ./WCSimRootDict.h
   These are the Root dictionary files created by rootcint
 (they are not in the repository); they are made by 
 gmake rootcint


### PR DESCRIPTION
Both building methods, the one using GNU make and the other one using CMake, should create ROOT dictionaries with the ".cxx" file extension (up to now, the first method was creating a ".cc" file). These automatically created source code files should not pollute the "src/" directory (following the general ROOT rules, they should be created in the current "build" directory).