### PR TITLE
gamma-conversion 

### DIFF
--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -3,6 +3,7 @@
 
 #include "G4VUserPrimaryGeneratorAction.hh"
 #include "G4ThreeVector.hh"
+#include "G4ParticleDefinition.hh"
 #include "globals.hh"
 
 #include "WCSimEnumerations.hh"
@@ -119,6 +120,11 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
         float fNuBeamAng;
         float fNuPlanePos[3];
 
+        bool needConversion;
+        bool foundConversion;
+        const G4ParticleDefinition * conversionProductParticle[2];
+        G4ThreeVector conversionProductMomentum[2];
+	
     public:
 
         inline TFile* GetInputRootrackerFile(){ return fInputRootrackerFile;}
@@ -160,6 +166,13 @@ class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
   
         inline void SetPoissonPMTMean(G4double val){ poissonPMTMean = val; }
         inline G4double GetPoissonPMTMean(){ return poissonPMTMean; }
+	
+        inline bool IsConversionFound(){ return foundConversion; }
+        inline void FoundConversion(){ foundConversion = true; }
+        inline void SetConversionProductParticle(int i, const G4ParticleDefinition *p) { conversionProductParticle[i] = p; }
+        inline void SetConversionProductMomentum(int i, const G4ThreeVector& p) { conversionProductMomentum[i] = p; }
+        inline void SetNeedConversion(bool choice) { needConversion = choice; foundConversion = !choice; }
+        inline bool NeedsConversion() { return needConversion; }
 };
 
 #endif

--- a/include/WCSimTrackingAction.hh
+++ b/include/WCSimTrackingAction.hh
@@ -33,6 +33,8 @@ private:
   G4float percentageOfCherenkovPhotonsToDraw;
 
   WCSimTrackingMessenger* messenger;
+  
+  G4int primaryID;
 };
 
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -138,6 +138,9 @@ void WCSimEventAction::BeginOfEventAction(const G4Event*)
 void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 {
 
+  if(evt->IsAborted() || evt->GetEventID() < 0){
+      return;
+  }	
   // ----------------------------------------------------------------------
   //  Get Particle Table
   // ----------------------------------------------------------------------

--- a/src/WCSimPrimaryGeneratorMessenger.cc
+++ b/src/WCSimPrimaryGeneratorMessenger.cc
@@ -15,10 +15,10 @@ WCSimPrimaryGeneratorMessenger::WCSimPrimaryGeneratorMessenger(WCSimPrimaryGener
   genCmd = new G4UIcmdWithAString("/mygen/generator",this);
   genCmd->SetGuidance("Select primary generator.");
 
-  genCmd->SetGuidance(" Available generators : muline, gun, laser, gps, rootracker");
+  genCmd->SetGuidance(" Available generators : muline, gun, laser, gps, rootracker, gamma-conversion");
   genCmd->SetParameterName("generator",true);
   genCmd->SetDefaultValue("muline");
-  genCmd->SetCandidates("muline gun laser gps rootracker");
+  genCmd->SetCandidates("muline gun laser gps rootracker, gamma-conversion");
 
   fileNameCmd = new G4UIcmdWithAString("/mygen/vecfile",this);
   fileNameCmd->SetGuidance("Select the file of vectors.");
@@ -83,6 +83,7 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
       myAction->SetRootrackerEvtGenerator(false);
       myAction->SetLaserEvtGenerator(false);
       myAction->SetGPSEvtGenerator(true);
+      myAction->SetNeedConversion(false);	    
     }
     else if ( newValue == "rootracker")   //M. Scott: Addition of Rootracker events
     {
@@ -92,6 +93,15 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
       myAction->SetLaserEvtGenerator(false);
       myAction->SetGPSEvtGenerator(false);
     }
+    else if ( newValue == "gamma-conversion")
+    {
+      myAction->SetMulineEvtGenerator(false);
+      myAction->SetRootrackerEvtGenerator(false);
+      myAction->SetGunEvtGenerator(false);
+      myAction->SetLaserEvtGenerator(false);
+      myAction->SetGPSEvtGenerator(true);
+      myAction->SetNeedConversion(true);
+    }	  
   }
 
   if( command == fileNameCmd )
@@ -140,7 +150,7 @@ G4String WCSimPrimaryGeneratorMessenger::GetCurrentValue(G4UIcommand* command)
     else if(myAction->IsUsingLaserEvtGenerator())
       { cv = "laser"; }   //T. Akiri: Addition of laser
     else if(myAction->IsUsingGPSEvtGenerator())
-      { cv = "gps"; }
+       { cv = myAction->NeedsConversion() ? "gamma-conversion" : "gps"; }
     else if(myAction->IsUsingRootrackerEvtGenerator())
       { cv = "rootracker"; }   //M. Scott: Addition of Rootracker events
   }

--- a/src/WCSimSteppingAction.cc
+++ b/src/WCSimSteppingAction.cc
@@ -23,6 +23,9 @@ G4int WCSimSteppingAction::n_photons_on_smallPMT = 0;
 
 void WCSimSteppingAction::UserSteppingAction(const G4Step* aStep)
 {
+    const G4Event *event = G4EventManager::GetEventManager()->GetConstCurrentEvent();
+    if(event->IsAborted() || event->GetEventID() < 0)
+      return;
   //DISTORTION must be used ONLY if INNERTUBE or INNERTUBEBIG has been defined in BidoneDetectorConstruction.cc
   
   const G4Track* track       = aStep->GetTrack();

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -5,8 +5,10 @@
 #include "G4Track.hh"
 #include "G4ios.hh"
 #include "G4VProcess.hh"
+#include "G4RunManager.hh"
 #include "WCSimTrackInformation.hh"
 #include "WCSimTrackingMessenger.hh"
+#include "WCSimPrimaryGeneratorAction.hh"
 
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
@@ -60,6 +62,20 @@ void WCSimTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
     }
   else 
     fpTrackingManager->SetStoreTrajectory(false);
+	
+    WCSimPrimaryGeneratorAction *primaryGenerator = (WCSimPrimaryGeneratorAction *) (G4RunManager::GetRunManager()->GetUserPrimaryGeneratorAction());
+    if(!primaryGenerator->IsConversionFound()) {
+      if(aTrack->GetParentID()==0){
+          primaryID = aTrack->GetTrackID();
+      }
+      else if(aTrack->GetParentID() == primaryID) {
+          if (aTrack->GetCreatorProcess()->GetProcessName() == "conv") {
+              primaryGenerator->FoundConversion();
+          }
+          G4EventManager::GetEventManager()->AbortCurrentEvent();
+          G4EventManager::GetEventManager()->GetNonconstCurrentEvent()->SetEventAborted();
+      }
+  }
 }
 
 void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
@@ -179,6 +195,17 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
     if (anInfo->isSaved())
       currentTrajectory->SetSaveFlag(true);// mark it for WCSimEventAction ;
     else currentTrajectory->SetSaveFlag(false);// mark it for WCSimEventAction ;
+  }
+	
+  WCSimPrimaryGeneratorAction *primaryGenerator = (WCSimPrimaryGeneratorAction *) (G4RunManager::GetRunManager()->GetUserPrimaryGeneratorAction());
+  if(!primaryGenerator->IsConversionFound() && 
+     aTrack->GetTrackID() == primaryID &&
+     aTrack->GetStep()->GetPostStepPoint()->GetProcessDefinedStep() &&
+     aTrack->GetStep()->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() == "conv"){
+      for(int i=0; i<2; i++){
+          primaryGenerator->SetConversionProductParticle(i, secondaries->at(i)->GetParticleDefinition());
+          primaryGenerator->SetConversionProductMomentum(i, secondaries->at(i)->GetMomentum());
+      }
   }
 }
 


### PR DESCRIPTION
To enable the gamma-conversion generator in WCSim (https://github.com/nickwp/WCSim/compare/01cc7e4d..8c414f4a)

   1. For gammas, gamma-conversion is usually used to initially generate events in the centre of the tank until they convert into a positron and electron.
   2.  It will then simulate the positron and electron starting again from the original position to produce the final output.
   3. Thus gamma events are considered to convert at the specified position rather than produced at that position, to provide unbiased comparisons with electron events.
